### PR TITLE
weave is a separate project now

### DIFF
--- a/libprism/local/HMM.py
+++ b/libprism/local/HMM.py
@@ -7,7 +7,7 @@ from libprism.common.math import logsumexp
 
 import numpy as np
 
-from scipy.weave import inline, converters
+from weave import inline, converters
 from libprism.local.prepare import verify_complexity, blocks_from_clouds, contigs_from_clouds
 
 class HMM(object):


### PR DESCRIPTION
fixes problem with import error that is inevitably raised as a result of weave being in a separate project outside of scipy